### PR TITLE
Fix start timer service when only one vial installed & add additional check if specific slot is selected

### DIFF
--- a/custom_components/pura/const.py
+++ b/custom_components/pura/const.py
@@ -13,3 +13,4 @@ ATTR_INTENSITY: Final = "intensity"
 ATTR_DURATION: Final = "duration"
 
 ERROR_AWAY_MODE: Final = "Away mode is currently active. Return to your space or disable away mode in order to control your diffuser."
+ERROR_NO_SLOTS_INSTALLED: Final = "Pura is reporting that no fragrance vials are installed."

--- a/custom_components/pura/select.py
+++ b/custom_components/pura/select.py
@@ -118,18 +118,15 @@ class PuraSelectEntity(PuraEntity, SelectEntity):
         self, *, slot: int | None = None, intensity: int, duration: timedelta
     ) -> None:
         """Start a fragrance timer."""
-        installed_slots: list[int] = []
         device = self.get_device()
-        for i in (1,2):
-            if has_fragrance(device, i):
-                installed_slots.append(i)
+        installed_slots: list[int] = [i for i in (1,2) if has_fragrance(device, i)]
+        if not installed_slots:
+            raise PuraApiException(ERROR_NO_SLOTS_INSTALLED)
         if not slot:
             runtime = "wearingTime"
             if len(installed_slots) == 2:
                 slot = 1 if device["bay1"][runtime] <= device["bay2"][runtime] else 2
             else:
-                if not installed_slots:
-                    raise PuraApiException(ERROR_NO_SLOTS_INSTALLED)
                 slot = installed_slots[0]
         else:
             if slot not in installed_slots:


### PR DESCRIPTION
At the moment, if no slot is specified, the `start_timer` service will automatically select `slot 2` if a user only has one vial installed (in particular in `slot 1`). A Pura device that only has a vial in `slot 1` will return a `bay2` `wearingTime` of `0`. As a result, if the `wearingTime` for `bay1` is greater than `0`, `slot 2` will be the automatically selected slot instead of `slot 1` even though no fragrance vial is installed in `bay2`.

Example data returned by Pura API when only `bay1` slot has a fragrance vial:
```
'bay2': {'msg': '', 'wearingTime': 0, 'code': '', 'min': 64, 'max': 85, 'vialId': '', 'id': 0, 'activeAt': 0, 'isSmartVial': False}, 'connected': True, 'bay1': {'msg': '', 'wearingTime': 344869, 'code': 'SVA', 'min': 64, 'max': 85, 'vialId': 'e66a6e37-7259-4c7f-94b8-17455703e008', 'id': 1694623148, 'activeAt': 0, 'isSmartVial': False}
```

**In order to get around this, if a user hasn't selected a slot:** 
1) We first check to see what slots are occupied and create a `installed_slots` list.
2) If determined that both `bay1` and `bay2` are occupied, then we compare `wearingTime`
3) If only `bay1` or `bay2` has a vial installed, then whichever one has a vial is determined to be the automatically selected slot.
4) In addition, a check is performed, and exception raised in the event that the user is attempting to call the `start_timer` on the device that has no vials installed.


**If a user selects a specific slot:**
An exception is raised indicating that the selected slot doesn't have a vial installed if the slot is not found in the `installed_slots` list.