### PR TITLE
Add configurable polling interval with jitter and exponential backoff

### DIFF
--- a/custom_components/pura/__init__.py
+++ b/custom_components/pura/__init__.py
@@ -61,7 +61,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PuraConfigEntry) -> bool
     except Exception as ex:
         raise ConfigEntryNotReady(ex) from ex
 
-    coordinator = PuraDataUpdateCoordinator(hass, client=client)
+    coordinator = PuraDataUpdateCoordinator(hass, client=client, config_entry=entry)
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator

--- a/custom_components/pura/const.py
+++ b/custom_components/pura/const.py
@@ -8,6 +8,14 @@ DOMAIN: Final = "pura"
 
 CONF_ID_TOKEN: Final = "id_token"
 CONF_REFRESH_TOKEN: Final = "refresh_token"
+CONF_UPDATE_INTERVAL: Final = "update_interval"
+
+MIN_UPDATE_INTERVAL: Final = 30
+MAX_UPDATE_INTERVAL: Final = 300
+DEFAULT_UPDATE_INTERVAL: Final = 30
+MAX_JITTER: Final = 30  # Maximum jitter in seconds (50% of interval, capped at 30s)
+BACKOFF_MULTIPLIER: Final = 2  # Max backoff = user interval * this
+MIN_MAX_BACKOFF: Final = 300  # 5 minute floor for max backoff
 
 ATTR_SLOT: Final = "slot"
 ATTR_INTENSITY: Final = "intensity"

--- a/custom_components/pura/coordinator.py
+++ b/custom_components/pura/coordinator.py
@@ -5,36 +5,99 @@ from __future__ import annotations
 import copy
 from datetime import timedelta
 import logging
+import random
 from typing import Any
 
 from deepdiff import DeepDiff
 from pypura import Pura
 from pypura.ws_subscriber import WebSocketSubscriber
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN
+from .const import (
+    BACKOFF_MULTIPLIER,
+    CONF_UPDATE_INTERVAL,
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+    MAX_JITTER,
+    MIN_MAX_BACKOFF,
+)
 from .helpers import deep_merge, get_device_id
 
 _LOGGER = logging.getLogger(__name__)
-UPDATE_INTERVAL = 30
 
 
-class PuraDataUpdateCoordinator(DataUpdateCoordinator):
+class JitterBackoffMixin:
+    """Mixin to add jitter and exponential backoff to coordinators."""
+
+    _base_interval: float
+    _consecutive_failures: int
+    update_interval: timedelta
+
+    def _init_jitter_backoff(self, config_entry: ConfigEntry) -> None:
+        """Initialize jitter and backoff settings from config entry."""
+        self._base_interval = config_entry.options.get(
+            CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL
+        )
+        self._consecutive_failures = 0
+
+    def _get_interval_with_jitter(self) -> timedelta:
+        """Calculate the update interval with jitter (50% of interval, capped at 30s)."""
+        interval = self._base_interval
+        # Calculate jitter as 50% of base interval, capped at MAX_JITTER
+        jitter_max = min(self._base_interval * 0.5, MAX_JITTER)
+        jitter = random.uniform(0, jitter_max)
+        interval += jitter
+        _LOGGER.debug(
+            "Next update in %.1fs (base: %ds, jitter: %.1fs)",
+            interval,
+            self._base_interval,
+            jitter,
+        )
+        return timedelta(seconds=interval)
+
+    def _handle_success(self) -> None:
+        """Handle successful API call - reset backoff and apply jitter to next interval."""
+        if self._consecutive_failures > 0:
+            _LOGGER.debug("API call succeeded, resetting backoff")
+            self._consecutive_failures = 0
+        self.update_interval = self._get_interval_with_jitter()
+
+    def _handle_failure(self, context: str) -> None:
+        """Handle failed API call - apply exponential backoff."""
+        self._consecutive_failures += 1
+        max_backoff = max(self._base_interval * BACKOFF_MULTIPLIER, MIN_MAX_BACKOFF)
+        backoff = min(2**self._consecutive_failures, max_backoff)
+        new_interval = self._base_interval + backoff
+        self.update_interval = timedelta(seconds=new_interval)
+        _LOGGER.debug(
+            "%s failed (attempt %d), next update in %ds",
+            context,
+            self._consecutive_failures,
+            new_interval,
+        )
+
+
+class PuraDataUpdateCoordinator(JitterBackoffMixin, DataUpdateCoordinator):
     """Class to manage fetching data from the API."""
 
-    def __init__(self, hass: HomeAssistant, client: Pura) -> None:
+    def __init__(
+        self, hass: HomeAssistant, client: Pura, config_entry: ConfigEntry
+    ) -> None:
         """Initialize."""
         self.api = client
         self.devices: dict[str, list[dict[str, Any]]] = {}
+
+        self._init_jitter_backoff(config_entry)
 
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(seconds=UPDATE_INTERVAL),
+            update_interval=self._get_interval_with_jitter(),
         )
 
         self.subscriber = WebSocketSubscriber(
@@ -91,7 +154,7 @@ class PuraDataUpdateCoordinator(DataUpdateCoordinator):
         else:
             _LOGGER.warning("Received unknown update: %s", data)
 
-    async def _async_update_data(self):
+    async def _async_update_data(self) -> dict[str, list[dict[str, Any]]]:
         """Update data via library, refresh token if necessary."""
         try:
             if devices := await self.hass.async_add_executor_job(self.api.get_devices):
@@ -104,40 +167,57 @@ class PuraDataUpdateCoordinator(DataUpdateCoordinator):
                 )
                 _LOGGER.debug("Devices updated: %s", diff if diff else "no changes")
                 self.devices = devices
+
+            self._handle_success()
+
         except Exception as err:  # pylint: disable=broad-except
+            self._handle_failure("Pura API update")
             _LOGGER.error(
-                "Unknown exception while updating Pura data: %s", err, exc_info=1
+                "Exception while updating Pura data: %s",
+                err,
+                exc_info=True,
             )
             raise UpdateFailed(err) from err
         return self.devices
 
 
-class PuraCarFirmwareDataUpdateCoordinator(DataUpdateCoordinator):
+class PuraCarFirmwareDataUpdateCoordinator(JitterBackoffMixin, DataUpdateCoordinator):
     """Class to manage fetching data from the API."""
 
-    def __init__(self, hass: HomeAssistant, client: Pura) -> None:
+    def __init__(
+        self, hass: HomeAssistant, client: Pura, config_entry: ConfigEntry
+    ) -> None:
         """Initialize."""
         self.api = client
+
+        self._init_jitter_backoff(config_entry)
 
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(seconds=UPDATE_INTERVAL),
+            update_interval=self._get_interval_with_jitter(),
         )
 
-    async def _async_update_data(self):
+    async def _async_update_data(self) -> dict[str, str]:
         """Update data via library, refresh token if necessary."""
         try:
             details: str = await self.hass.async_add_executor_job(
                 self.api.get_latest_firmware_details, "car", "v1"
             )
-            return {
+            result = {
                 (part := line.split("=", 1))[0].lower(): part[1]
                 for line in details.split("\n")
             }
+
+            self._handle_success()
+
+            return result
         except Exception as err:  # pylint: disable=broad-except
+            self._handle_failure("Pura car firmware API update")
             _LOGGER.error(
-                "Unknown exception while updating Pura data: %s", err, exc_info=1
+                "Exception while updating Pura car firmware data: %s",
+                err,
+                exc_info=True,
             )
             raise UpdateFailed(err) from err

--- a/custom_components/pura/strings.json
+++ b/custom_components/pura/strings.json
@@ -25,6 +25,18 @@
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "update_interval": "Update interval"
+        },
+        "data_description": {
+          "update_interval": "How often to poll the Pura API (seconds)"
+        }
+      }
+    }
+  },
   "entity": {
     "select": {
       "fragrance": {

--- a/custom_components/pura/translations/en.json
+++ b/custom_components/pura/translations/en.json
@@ -25,6 +25,18 @@
       "reauth_successful": "Re-authentication was successful"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "update_interval": "Update interval"
+        },
+        "data_description": {
+          "update_interval": "How often to poll the Pura API (seconds)"
+        }
+      }
+    }
+  },
   "entity": {
     "select": {
       "fragrance": {


### PR DESCRIPTION
  Add configurable polling interval with jitter and exponential backoff to prevent API rate limiting.

  Features:
  - Options flow UI to configure update interval (10-300s) and max jitter (0-60s)
  - Per-poll random jitter spreads requests over time
  - Exponential backoff on failures (capped at 5 minutes)
  - Auto-reset to normal interval on success

  Code Quality:
  - Extract JitterBackoffMixin to eliminate duplicate jitter/backoff logic
  - Fix jitter implementation to modify update_interval instead of sleeping (correctly varies polling times)
  - Add proper type annotations throughout


  Hopefully Helps With: #103


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Options UI to configure update behavior and improved reliability via jitter and exponential backoff.

* **Configuration**
  * New options: update interval (default 30s, range 30–300s) and jitter/backoff tuning; coordinator timing now respects these settings.

* **Localization**
  * Translations updated to include new options and descriptions in the config flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->