### PR TITLE
Fix KeyError when bay has no fragrance

### DIFF
--- a/custom_components/pura/binary_sensor.py
+++ b/custom_components/pura/binary_sensor.py
@@ -41,7 +41,7 @@ SENSORS: dict[tuple[str, ...], tuple[PuraBinarySensorEntityDescription, ...]] = 
             key="low_fragrance",
             name="Low fragrance",
             device_class=BinarySensorDeviceClass.PROBLEM,
-            on_fn=lambda data: data["bay1"]["lowFragrance"],
+            on_fn=lambda data: data.get("bay1", {}).get("lowFragrance", False),
         ),
     ),
     ("wall", "plus", "mini"): (

--- a/custom_components/pura/calendar.py
+++ b/custom_components/pura/calendar.py
@@ -93,8 +93,8 @@ class PuraCalendarEntity(CoordinatorEntity[PuraDataUpdateCoordinator], CalendarE
                 end=_parse_datetime(now, schedule["end"], schedule["disableUntil"]),
                 description=f"Fragrance slot {schedule['bay']} ("
                 + (
-                    bay["fragrance"]["name"]
-                    if (bay := device[f"bay{schedule['bay']}"])
+                    bay.get("fragrance", {}).get("name", "Unknown")
+                    if (bay := device.get(f"bay{schedule['bay']}"))
                     else "Empty"
                 )
                 + f") with {schedule['intensity']} intensity",


### PR DESCRIPTION
Use defensive .get() calls to handle cases where a bay exists but doesn't have a fragrance inserted, preventing KeyError exceptions.

https://github.com/natekspencer/hacs-pura/issues/105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of fragrance status detection by gracefully handling missing or incomplete device data, preventing errors when expected fields are absent.
  * Calendar descriptions now tolerate missing bay or fragrance details and show sensible defaults instead of failing.
  * No changes to public interfaces; behavior is more resilient while preserving existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->