### PR TITLE
Fix hassfest validation errors

### DIFF
--- a/custom_components/pura/__init__.py
+++ b/custom_components/pura/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.typing import ConfigType
 
@@ -32,6 +33,8 @@ PLATFORMS = [
     Platform.SWITCH,
     Platform.UPDATE,
 ]
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/custom_components/pura/services.yaml
+++ b/custom_components/pura/services.yaml
@@ -2,18 +2,14 @@
 
 start_timer:
   target:
-    device:
-      - integration: pura
-        model: Pura 3
-      - integration: pura
-        model: Pura 4
-      - integration: pura
-        model: Pura Plus
-      - integration: pura
-        model: Pura Mini
     entity:
       - integration: pura
   fields:
+    device_id:
+      required: false
+      selector:
+        device:
+          integration: pura
     slot:
       required: false
       example: 1


### PR DESCRIPTION
- Remove device filters from service target (no longer supported)
- Add device selector to fields instead
- Add CONFIG_SCHEMA for config-entry-only integration

Fixes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the start_timer service configuration to require explicit device selection instead of model-based targeting. A new optional device_id selector field has been added to improve device specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->