### PR TITLE
Fix Calendar error with end time > start time.

### DIFF
--- a/custom_components/pura/calendar.py
+++ b/custom_components/pura/calendar.py
@@ -22,7 +22,6 @@ from .coordinator import PuraDataUpdateCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 SCHEDULE = EntityDescription(key="schedule")
-
 ONE_DAY = timedelta(days=1)
 
 
@@ -67,6 +66,7 @@ class PuraCalendarEntity(CoordinatorEntity[PuraDataUpdateCoordinator], CalendarE
         events = self._calendar.timeline_tz(now.tzinfo).active_after(now)
         if not (event := next(events, None)):
             return None
+
         return _get_calendar_event(event)
 
     async def async_get_events(
@@ -86,6 +86,7 @@ class PuraCalendarEntity(CoordinatorEntity[PuraDataUpdateCoordinator], CalendarE
         """Handle updated data from the coordinator."""
         now = dt_util.now()
         self._calendar = Calendar()
+
         self._calendar.events.extend(
             Event(
                 summary=f"{schedule['name']} - {device['displayName']['name']}",
@@ -100,7 +101,8 @@ class PuraCalendarEntity(CoordinatorEntity[PuraDataUpdateCoordinator], CalendarE
                 + f") with {schedule['intensity']} intensity",
                 uid=schedule["id"],
                 rrule=Recur.from_rrule(
-                    f"FREQ=WEEKLY;BYDAY={','.join(day[:2].upper() for day in schedule['days'] if schedule['days'][day])};INTERVAL=1"
+                    f"FREQ=WEEKLY;BYDAY="
+                    f"{','.join(day[:2].upper() for day in schedule['days'] if schedule['days'][day])};INTERVAL=1"
                 ),
             )
             for device_type, devices in self.coordinator.devices.items()
@@ -121,24 +123,40 @@ class PuraCalendarEntity(CoordinatorEntity[PuraDataUpdateCoordinator], CalendarE
 def _parse_datetime(
     now: datetime, time_str: str, disable_until: int | None = None
 ) -> datetime | None:
-    """Parse datetime."""
-    _date = dt_util.dt.datetime.combine(now, _parse_time(time_str), now.tzinfo)
+    """Parse datetime safely."""
+    # FIX: Use now.date() instead of invalid combine(now, ...)
+    base_time = _parse_time(time_str)
+    _date = datetime.combine(now.date(), base_time, now.tzinfo)
+
+    # If disabled until a future timestamp, move event to next day
     if disable_until and _date <= datetime.fromtimestamp(disable_until, now.tzinfo):
         _date += ONE_DAY
+
     return _date
 
 
 def _parse_time(time_str: str) -> dt_util.dt.time | None:
-    """Parse time."""
+    """Parse HHMM string into time."""
     return dt_util.parse_time(f"{time_str[:2]}:{time_str[2:]}")
 
 
 def _get_calendar_event(event: Event) -> CalendarEvent:
-    """Return a CalendarEvent from an iCal Event."""
+    """Convert an iCal Event to a safe Home Assistant CalendarEvent."""
+    start = dt_util.as_local(event.start)
+    end = dt_util.as_local(event.end) if event.end else None
+
+    # FIX 1: Missing end time → zero-duration event
+    if end is None:
+        end = start
+
+    # FIX 2: Overnight or reversed event (00:00 < 22:00) → add one day
+    if end < start:
+        end = end + ONE_DAY
+
     return CalendarEvent(
         summary=event.summary,
-        start=dt_util.as_local(event.start),
-        end=dt_util.as_local(event.end),
+        start=start,
+        end=end,
         description=event.description,
-        rrule=event.rrule.as_rrule_str(),
+        rrule=event.rrule.as_rrule_str() if event.rrule else None,
     )


### PR DESCRIPTION
Fix calendar creation issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calendar event time parsing to correctly handle date creation and timezone localization for event times.
  * Improved overnight event handling to properly advance end time when it occurs before start time.
  * Enhanced handling of missing end times to default to start time.
  * Fixed recurring rule handling in calendar events.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->