### PR TITLE
Use appropriate firmware version check for Car vs Car Pro models

### DIFF
--- a/custom_components/pura/update.py
+++ b/custom_components/pura/update.py
@@ -72,7 +72,8 @@ class PuraUpdateEntity(PuraEntity, UpdateEntity):
 
     async def async_update(self) -> None:
         """Update the entity."""
-        version = "v2" if "Pro" in determine_pura_model(self.get_device()) else "v1"
+        model = determine_pura_model(self.get_device()) or ""
+        version = "v2" if "Pro" in model else "v1"
         try:
             details: str = await self.hass.async_add_executor_job(
                 self.coordinator.api.get_latest_firmware_details, "car", version


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Firmware selection is now device-model aware: Pro devices receive v2 firmware while other models receive v1, improving accuracy of latest firmware detection and compatibility.
  * Result: more reliable, appropriate firmware updates with no action required from users; existing integrations and settings remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->